### PR TITLE
修复遇到不对的链接没有返回

### DIFF
--- a/src/dotnetCampus.FileDownloader.WPF/MainWindow.xaml.cs
+++ b/src/dotnetCampus.FileDownloader.WPF/MainWindow.xaml.cs
@@ -43,6 +43,8 @@ namespace dotnetCampus.FileDownloader.WPF
 
             if (Regex.IsMatch(text, @"^((https|http|ftp|rtsp|mms)?:\/\/)[^\s]+"))
             {
+                // 先清除，然后赋值，这样可以自动获取文件名
+                ViewModel.AddFileDownloadViewModel.CurrentDownloadFilePath = string.Empty;
                 ViewModel.AddFileDownloadViewModel.CurrentDownloadUrl = text;
             }
         }
@@ -163,5 +165,5 @@ namespace dotnetCampus.FileDownloader.WPF
 
             ViewModel.DownloadFileInfoList.Remove(downloadFileInfo);
         }
-    }
+    } 
 }

--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -74,6 +74,17 @@ namespace dotnetCampus.FileDownloader
 
             var (response, contentLength) = await GetContentLength();
 
+            _logger.LogInformation($"ContentLength={contentLength}");
+
+            if (contentLength < 0)
+            {
+                // contentLength == -1
+                // 当前非下载内容，没有存在长度
+                // 可测试使用的链接是 https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-windows-x64-installer
+                _logger.LogWarning($"Can not download file. ContentLength={contentLength}");
+                return;
+            }
+
             FileStream = File.Create();
             FileStream.SetLength(contentLength);
             FileWriter = new RandomFileWriter(FileStream);
@@ -154,7 +165,7 @@ namespace dotnetCampus.FileDownloader
                 try
                 {
                     var url = Url;
-                    var webRequest = (HttpWebRequest) WebRequest.Create(url);
+                    var webRequest = (HttpWebRequest)WebRequest.Create(url);
                     webRequest.Method = "GET";
 
                     action?.Invoke(webRequest);


### PR DESCRIPTION
遇到不对的链接不下载，而是方法返回

测试下载 https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-windows-x64-installer 可以返回 ContentLength 是 -1 此时就应该添加日志返回