### PR TITLE
优化控制开关 解决多个线程重入都进入暂停，此时没有进程再次执行，让下载继续

### DIFF
--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -104,8 +104,8 @@ namespace dotnetCampus.FileDownloader
 
             while (!SegmentManager.IsFinished())
             {
-                var (segment, runCount, maxReportTime) = SegmentManager
-                    .GetDownloadSegmentStatus();
+                _logger.LogDebug("Start ControlSwitch");
+                var (segment, runCount, maxReportTime) = SegmentManager.GetDownloadSegmentStatus();
                 int waitCount = DownloadDataList.Count;
 
                 _logger.LogDebug("当前等待数量：{0},待命最大响应时间：{1},运行数量：{2}", waitCount, maxReportTime, runCount);
@@ -114,14 +114,17 @@ namespace dotnetCampus.FileDownloader
                 {
                     // 此时速度太慢
                     segment.LoadingState = DownloadingState.Pause;
+                    _logger.LogDebug("ControlSwitch slowly pause segment={0}", segment.Number);
                 }
                 else if (maxReportTime < TimeSpan.FromMilliseconds(600) && waitCount > 0 || runCount < 1)
                 {
                     // 速度非常快，尝试再开线程，或者当前没有在进行的任务
                     // 如果此时是刚好全部完成了，而 runCount 是 0 进入 StartDownloadTask 也将会啥都不做
+                    _logger.LogDebug("ControlSwitch StartDownloadTask");
                     StartDownloadTask();
                 }
 
+                _logger.LogDebug("Finish ControlSwitch");
                 //变速器3秒为一周期
                 await Task.Delay(ControlDelayTime);
             }

--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -114,7 +114,7 @@ namespace dotnetCampus.FileDownloader
                 var (segment, runCount, maxReportTime) = SegmentManager.GetDownloadSegmentStatus();
                 int waitCount = DownloadDataList.Count;
 
-                _logger.LogDebug("ControlSwitch 当前等待数量：{0},待命最大响应时间：{1},运行数量：{2}", waitCount, maxReportTime, runCount);
+                _logger.LogDebug("ControlSwitch 当前等待数量：{0},待命最大响应时间：{1},运行数量：{2},运行线程{3}", waitCount, maxReportTime, runCount, _threadCount);
 
                 if (maxReportTime > TimeSpan.FromSeconds(10) && segment != null && runCount > 1)
                 {

--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -60,7 +60,9 @@ namespace dotnetCampus.FileDownloader
         /// 下载链接
         /// </summary>
         public string Url { get; }
+
         private AsyncQueue<DownloadData> DownloadDataList { get; } = new AsyncQueue<DownloadData>();
+
         /// <summary>
         /// 下载的文件
         /// </summary>
@@ -178,7 +180,7 @@ namespace dotnetCampus.FileDownloader
             if (supportSegment)
             {
                 // 先根据文件的大小，大概是 1M 让一个线程下载，至少需要开两个线程，最多是 10 个线程
-                var threadCount = (int)(contentLength / 1024 / 1024);
+                var threadCount = (int) (contentLength / 1024 / 1024);
                 _maxThread = Math.Max(Math.Min(2, threadCount), 10);
             }
             else
@@ -243,15 +245,15 @@ namespace dotnetCampus.FileDownloader
                 {
                     var url = Url;
                     _logger.LogDebug("[GetWebResponseAsync] [{0}] Create WebRequest. Retry Count {0}", id, i);
-                    var webRequest = (HttpWebRequest)WebRequest.Create(url);
+                    var webRequest = (HttpWebRequest) WebRequest.Create(url);
                     webRequest.Method = "GET";
                     // 加上超时，支持弱网
                     // Timeout设置的是从发出请求开始算起，到与服务器建立连接的时间
                     // ReadWriteTimeout设置的是从建立连接开始，到下载数据完毕所历经的时间
                     // 即使下载速度再慢，只有要在下载，也不能算超时
                     // 如果下载 BufferLength 长度 默认 65535 字节时间超过 10 秒，基本上也断开也差不多
-                    webRequest.Timeout = (int)StepTimeOut.TotalMilliseconds;
-                    webRequest.ReadWriteTimeout = (int)StepTimeOut.TotalMilliseconds;
+                    webRequest.Timeout = (int) StepTimeOut.TotalMilliseconds;
+                    webRequest.ReadWriteTimeout = (int) StepTimeOut.TotalMilliseconds;
 
                     _logger.LogDebug("[GetWebResponseAsync] [{0}] Enter action.", id);
                     action?.Invoke(webRequest);
@@ -436,6 +438,7 @@ namespace dotnetCampus.FileDownloader
                 {
                     break;
                 }
+
                 if (downloadSegment.Finished)
                 {
                     break;

--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -506,7 +506,7 @@ namespace dotnetCampus.FileDownloader
 
             await FileWriter.DisposeAsync();
             await FileStream.DisposeAsync();
-            DownloadDataList.Dispose();
+            await DownloadDataList.DisposeAsync();
 
             FileDownloadTask.SetResult(true);
         }

--- a/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentFileDownloader.cs
@@ -107,7 +107,9 @@ namespace dotnetCampus.FileDownloader
                 var (segment, runCount, maxReportTime) = SegmentManager
                     .GetDownloadSegmentStatus();
                 int waitCount = DownloadDataList.Count;
-                Debug.WriteLine($"当前等待数量：{waitCount},待命最大响应时间：{maxReportTime},运行数量：{runCount}");
+
+                _logger.LogDebug("当前等待数量：{0},待命最大响应时间：{1},运行数量：{2}", waitCount, maxReportTime, runCount);
+
                 if (maxReportTime > TimeSpan.FromSeconds(10) && segment != null && runCount > 1)
                 {
                     // 此时速度太慢

--- a/src/dotnetCampus.FileDownloader/SegmentManager.cs
+++ b/src/dotnetCampus.FileDownloader/SegmentManager.cs
@@ -54,20 +54,21 @@ namespace dotnetCampus.FileDownloader
                 return DownloadSegmentList.TrueForAll(segment => segment.Finished);
             }
         }
-        public void GetDownloadSegmentStatus(out DownloadSegment? segment, out int runCount, out double maxReportTime)
+
+        internal (DownloadSegment? segment, int runCount, TimeSpan maxReportTime) GetDownloadSegmentStatus()
         {
             lock (_locker)
             {
                 int maxCount = DownloadSegmentList.Count;
-                maxReportTime = 0;
-                runCount = 0;
-                segment = null;
+                TimeSpan maxReportTime = TimeSpan.MinValue;
+                int runCount = 0;
+                DownloadSegment? segment = null;
                 for (int i = 0; i < maxCount; i++)
                 {
                     DownloadSegment downloadSegment = DownloadSegmentList[i];
                     if (downloadSegment.LoadingState == DownloadingState.Runing)
                     {
-                        double reportTime = (DateTime.Now - downloadSegment.LastDownTime).TotalMilliseconds;
+                        var reportTime = (DateTime.Now - downloadSegment.LastDownTime);
                         if (reportTime >= maxReportTime)
                         {
                             maxReportTime = reportTime;
@@ -76,8 +77,11 @@ namespace dotnetCampus.FileDownloader
                         runCount++;
                     }
                 }
+
+                return (segment, runCount, maxReportTime);
             }
         }
+
         private DownloadSegment? NewDownloadSegment()
         {
             if (DownloadSegmentList.Count == 0)

--- a/src/dotnetCampus.FileDownloader/dotnetCampus.FileDownloader.csproj
+++ b/src/dotnetCampus.FileDownloader/dotnetCampus.FileDownloader.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.2.1">
+        <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.4.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
- 减少一个锁
- 减少有线程等待锁
- 解决线程等待锁没有释放的内存泄露

步骤：

有两个线程进入 ControlSwitch 方法，两个进程先后调用 GetDownloadSegmentStatus 方法，分别拿到两个不同的段。其中一个线程先进入设置暂停，然后另一个进程再进入设置暂停。然后两个线程都进入暂停，没有线程在运行，也就没有线程触发 ControlSwitch 方法

@maplewei 