### PR TITLE
Fix NETSDK1146

### DIFF
--- a/src/dotnetCampus.FileDownloader.WPF/dotnetCampus.FileDownloader.WPF.csproj
+++ b/src/dotnetCampus.FileDownloader.WPF/dotnetCampus.FileDownloader.WPF.csproj
@@ -17,4 +17,16 @@
     <ItemGroup>
         <ProjectReference Include="..\dotnetCampus.FileDownloader\dotnetCampus.FileDownloader.csproj" />
     </ItemGroup>
+
+    <Target Name="HackBeforePackToolValidation" BeforeTargets="_PackToolValidation">
+        <PropertyGroup>
+            <TargetPlatformIdentifier></TargetPlatformIdentifier>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="HackAfterPackToolValidation" AfterTargets="_PackToolValidation">
+        <PropertyGroup>
+            <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+        </PropertyGroup>
+    </Target>
 </Project>


### PR DESCRIPTION
C:\Program Files\dotnet\sdk\5.0.201\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.PackTool.targets(95,5): error NETSDK1146: PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.

https://github.com/dotnet/sdk/issues/16361

https://github.com/dotnet/sdk/issues/12055